### PR TITLE
Fix Timer test. Refactor Stats

### DIFF
--- a/timer.go
+++ b/timer.go
@@ -2,11 +2,8 @@ package main
 
 import (
 	"errors"
-	"fmt"
 	"sync"
 	"time"
-
-	"github.com/jan25/gocui"
 )
 
 // Timer is a stopwatch like functionality
@@ -29,8 +26,7 @@ type TimeFormatted struct {
 
 // NewTimer creates and returns new timer instance
 func NewTimer() *Timer {
-	var timer Timer
-	return &timer
+	return &Timer{}
 }
 
 // Start starts the timer
@@ -44,7 +40,6 @@ func (t *Timer) Start() error {
 	t.done = make(chan struct{})
 
 	t.wg.Add(1)
-	go t.updateTimer(g)
 	return nil
 }
 
@@ -105,30 +100,4 @@ func (t *Timer) elapsedDuration() (time.Duration, error) {
 	// return ~0 seconds
 	// is there better way to return `nil` time?
 	return time.Microsecond, errors.New("timer is not active")
-}
-
-func (t *Timer) updateTimer(g *gocui.Gui) {
-	defer t.wg.Done()
-
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-t.getDoneCh():
-			return
-		case <-ticker.C:
-			g.Update(func(g *gocui.Gui) error {
-				// TODO remove hardcoded view name
-				v, err := g.View("stats")
-				if err != nil {
-					return err
-				}
-				v.Clear()
-				elapsed, _ := t.ElapsedTime()
-				fmt.Fprintf(v, "%02d:%02d", elapsed.Mins, elapsed.Secs)
-				return nil
-			})
-		}
-	}
 }


### PR DESCRIPTION
- Fix failing timer tests
- Fixing above allowed to refactor Stats, Timer modules
- Now `stats.go` has responsibility to update the timer in the UI when race is in progress